### PR TITLE
Add 2 potentially useful tkldev tools (mostly for my own use)

### DIFF
--- a/bin/fab-investigate
+++ b/bin/fab-investigate
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+target=$1
+cp '/turnkey/fab/common/overlays/turnkey.d/systemd-chroot/usr/local/bin/service' "$target/usr/local/bin/service" || true
+fab-chroot $target
+

--- a/bin/fab-rewind
+++ b/bin/fab-rewind
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+
+target=$1
+
+function stop_services() {
+    targ=$1
+    fab-chroot build/$targ service mysql stop
+    fab-chroot build/$targ service apache2 stop
+}
+function undeck() {
+    targ=$1
+    if [ -d build/$targ ]; then
+        stop_services $targ
+        deck -D build/$targ
+    fi
+    if [ -f build/stamps/$targ ]; then
+        rm build/stamps/$targ
+    fi
+}
+
+case $target in
+    root.patched)
+        undeck root.sandbox
+        ;;
+    root.build)
+        undeck root.sandbox;
+        undeck root.patched
+        ;;
+    bootstrap)
+        undeck root.sandbox;
+        undeck root.patched;
+        undeck root.build
+        ;;
+    *)
+        echo "unknown target: $target" 1>&2;
+        echo "note: rewind TO $target, so select the latest target you want to still exist" 1>&2;
+esac


### PR DESCRIPTION
Add in the following

fab-investigate:
  fab-chroot wrapper that copies across the service common overlay as well, intended to setup an environment for messing about within a chroot, please add to this if anybodies got any ideas for convenient things to have inside a chroot.

fab-rewind:
  essentially a shorter way to rewind a deck back to a specific target, auto stops apache & mysql. Needs to be extended to support the less common services such as node, nginx, etc, etc.