### PR TITLE
Minor improvement to pool-refresh

### DIFF
--- a/bin/pool-refresh
+++ b/bin/pool-refresh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 for package_src in $@; do
-    pool-unregister $package_src
+    pool-unregister $package_src || true
 done
 pool-gc
 for package_src in $@; do


### PR DESCRIPTION
This is a super minor improvement so I will just merge it myself. But I decided to open a PR for transparency.

FWIW, there are circumstance where `pool-unregister` might fail (e.g. the branch that was previously registered no longer exists) but we want the `pool-refresh` function to complete.

FYI @OnGle 