### PR TITLE
Add squid clean

### DIFF
--- a/bin/tkldev-changelog
+++ b/bin/tkldev-changelog
@@ -91,11 +91,12 @@ if [ -z "$EXTRA_TEXT" ] && [ "$APP" != "core" ]; then
                 EXTRA_TEXT="${EXTRA_TEXT}$(cat "$change_fn")"$'\n\n'
             else
                 echo "error: common change \"$change_fn\" not found!"
-                exit 1
+                echo "Ignoring..."
+                #exit 1
             fi
         fi
     done
-    EXTRA_TEXT+="$(cat "${COMMON_CHANGES}/base")"$'\n'
+    EXTRA_TEXT+="$(cat "${COMMON_CHANGES}/base")"$'\n' || true
 fi
 
 EXTRA_TEXT_FILE="$(mktemp /tmp/tkldev-changelog.XXXXXX)"

--- a/bin/tkldev-squid-refresh
+++ b/bin/tkldev-squid-refresh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+echo "- Killing squid"
+kill -9 $(cat /run/squid.pid) || echo "Squid process ID not found, continuing"
+
+echo "- Deleteing squid's on disk cache files"
+find /var/spool/squid/ -maxdepth 1 -type d -name 0[0-9A-F] -exec rm -r {} +
+
+echo "- Clearing host's apt cache (host also uses squid)"
+apt clean
+find /var/lib/apt -type f \
+    \( -name "*\.turnkeylinux\.org*" -o -name "*\.debian\.org*" \) \
+    -exec rm {} +
+
+echo "- Restarting squid"
+systemctl start squid
+
+echo "- Updating host's apt lists (please wait)"
+apt-get update -qq
+
+echo "Done"


### PR DESCRIPTION
The main thing here is the new `tkldev-squid-refresh` script (to clear apt and squid caches).

It's likely that this will rarely be needed, but IMO it's nice to have a convenience script rather than having to hunt through docs and manually do it.