### PR TITLE
Improve tkldev-squid-refresh

### DIFF
--- a/bin/tkldev-squid-refresh
+++ b/bin/tkldev-squid-refresh
@@ -1,7 +1,11 @@
 #!/bin/bash -e
 
-echo "- Killing squid"
-kill -9 $(cat /run/squid.pid) || echo "Squid process ID not found, continuing"
+if [[ ! $(systemctl is-active -q squid) ]]; then
+    echo "- Killing squid"
+    kill -9 $(cat /run/squid.pid)
+else
+    echo "Squid process ID not found, continuing"
+fi
 
 echo "- Deleteing squid's on disk cache files"
 find /var/spool/squid/ -maxdepth 1 -type d -name 0[0-9A-F] -exec rm -r {} +


### PR DESCRIPTION
Minor tweak to improve UX - won't show error messages if squid not running (i.e. if `/run/squid.pid` doesn't exist).