### PR TITLE
dynamically resolve tkldev-changelog entries

### DIFF
--- a/bin/tkldev-changelog
+++ b/bin/tkldev-changelog
@@ -58,7 +58,7 @@ Environment::
     EMAIL               - email address of operator (if DEBEMAIL not set)
     EXTRA_TEXT          - additional changelog points to include in new entry
                           if not set; then by default it will read from 
-                          "/turnkey/fab/products/common-changes"
+                          "/turnkey/fab/common/changes"
     DEVDEBUG            - turn on debugging
 
 Future plans:
@@ -79,26 +79,11 @@ which vim > /dev/null || fatal "vim not found; call yourself a developer?!?"
 [ -f changelog ] || fatal "no changelog in local dir"
 
 APP=$(basename $PWD)
-COMMON_CHANGES="${FAB_PATH}/products/common-changes"
-COMMON_CHANGE_CHECKS=("lapp.mk" "lamp.mk" "nodejs.mk")
+COMMON_CHANGES="${FAB_PATH}/common/changes"
+APP_CHANGELOGS="$(tkldev-makefile-info "$PWD/Makefile"  -i | grep '/turnkey/fab/common' | rev | cut -d '/' -f 1 | rev | sed -E "s|^(.*).mk$|/${FAB_PATH}/common/changes/\1.changelog|")"
 
 if [ -z "$EXTRA_TEXT" ] && [ "$APP" != "core" ]; then
-    EXTRA_TEXT=""
-    for change_check in ${COMMON_CHANGE_CHECKS[@]}; do
-        if grep -Fq "$change_check" Makefile; then
-            change_fn="${COMMON_CHANGES}/${change_check%.mk}"
-            if [ -f "$change_fn" ]; then
-                EXTRA_TEXT="${EXTRA_TEXT}$(cat "$change_fn")"$'\n\n'
-            else
-                echo "error: common change \"$change_fn\" not found!"
-                echo "Ignoring..."
-                #exit 1
-            fi
-        fi
-    done
-
-    EXTRA_TEXT+="$(cat "${COMMON_CHANGES}/base" 2>/dev/null)"$'\n' \
-        || true
+    EXTRA_TEXT="$(tkldev-changelog-extractor "$PWD/changelog" $APP_CHANGELOGS)"
 fi
 
 EXTRA_TEXT_FILE="$(mktemp /tmp/tkldev-changelog.XXXXXX)"

--- a/bin/tkldev-changelog-extractor
+++ b/bin/tkldev-changelog-extractor
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from subprocess import check_output
+from os.path import isfile
+import sys
+import re
+
+CHANGE_HEAD=r'^turnkey-.*-(\d+)\.(\d+)-?(?:rc|beta)? \((\d+)\) .*$'
+CHANGE_FOOTER=r' -- .*'
+
+def error(msg):
+    print('ERROR: ' + msg, file=sys.stderr)
+def warn(msg):
+    print('WARN: ' + msg, file=sys.stderr)
+
+def process_changelog(path):
+    if not isfile(path):
+        warn(f"changelog {path} does not exist!")
+        return {}
+    changes = {}
+    current_v = None
+    skip = False
+
+    with open(path, 'r') as fob:
+        for line in fob:
+            matched = re.match(CHANGE_HEAD, line)
+            if matched:
+                major, minor, rel = matched.groups()
+                if len(major) > 3:
+                    skip = True
+                    continue
+                v = (int(major), int(minor), int(rel))
+                if v in changes:
+                    warn(f"duplicate version: {v}, condensing duplicate entries")
+                    current_v = v
+                    continue
+                assert v not in changes
+                changes[v] = []
+                current_v = v
+                continue
+
+            matched = re.match(CHANGE_FOOTER, line)
+            if matched:
+                current_v = None
+                skip = False
+                continue
+
+            if skip:
+                continue
+
+            if not line.strip():
+                continue
+
+            assert current_v is not None
+            if line.startswith('  *'):
+                changes[current_v].append(line)
+            else:
+                changes[current_v][-1] += line
+    return changes
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='''
+    tool for extracting changelog entries from one or more "common" changelogs
+    without duplicates.
+
+    Given some "changelog" and one or more "common" changelogs, take entries
+    from each common changelog which are newer than some version "from", but not
+    in the primary changelog.
+
+    ''')
+    parser.add_argument('-f', '--from',
+            help='only process entries more recent than this version (defaults to release of this tkldev)',
+            default=None,
+            metavar='MAJOR[.MINOR[.RELEASE]]',
+            dest='from_v')
+    parser.add_argument('changelog',
+            help='the changelog you\'re extracting entries for')
+    parser.add_argument('common',
+            help='return entries from these changelogs, not present in the primary changelog',
+            nargs='+')
+
+    args = parser.parse_args()
+
+    if args.from_v is None:
+        from_v = check_output(['turnkey-version', '-t'], text=True).strip()
+        if from_v.endswith('beta'):
+            from_v = from_v[:-4]
+        elif from_v.endswith('rc'):
+            from_v = from_v[:-2]
+    else:
+        from_v = args.from_v
+    if '.' in from_v:
+        from_v = from_v.split('.')
+        from_v = (*from_v, '0', '0')
+        if len(from_v) > 3:
+            from_v = from_v[:3]
+        from_v = tuple(map(int, from_v))
+    else:
+        from_v = (int(from_v), 0, 0)
+
+    # parse the changelog changes
+    primary = process_changelog(args.changelog)
+    common = [process_changelog(path) for path in args.common]
+    common_keys = set()
+    for chlg in common:
+        common_keys |= chlg.keys()
+
+    # remove entries older than some version
+    for key in primary.keys() | common_keys:
+        maj, min, rel = key
+        if (int(maj), int(min), int(rel)) < from_v:
+            if key in primary:
+                del primary[key]
+            for chlg in common:
+                if key in chlg:
+                    del chlg[key]
+
+    #all_primary_changes = [v for v in changes for changes in primary.values()]
+    all_primary_changes = [v for changes in primary.values() for v in changes]
+
+    for chlg in common:
+        for key in chlg.keys():
+            for change in chlg[key]:
+                if change not in all_primary_changes:
+                    print(change)
+
+    # output different changes
+    #print(json.dumps(changes, indent=4))

--- a/bin/tkldev-makefile-info
+++ b/bin/tkldev-makefile-info
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+from argparse import ArgumentParser
+
+try:
+    from libtkldet import mkparser
+except ImportError:
+    print("tkldev-detective not installed (required for makefile parser)",
+        file=sys.stderr)
+    os.exit(1)
+    
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='''
+Tool for getting variables and includes from makefiles.
+
+Mostly specialized for turnkey usage (cuts corners that might cause issues in
+broader applications)
+''')
+    parser.add_argument('makefile', metavar='path/to/Makefile')
+
+    selection_group = parser.add_mutually_exclusive_group()
+    selection_group.add_argument('-a', '--all',
+        help='(default) show everything', action='store_true')
+    selection_group.add_argument('-v', '--var', nargs='?',
+        metavar='VARNAME', const=True,
+        help='show all variables or specific variable if specified')
+    selection_group.add_argument('-i', '--included',
+        help='show all included', action='store_true')
+
+    format_group = parser.add_mutually_exclusive_group()
+
+    format_group.add_argument('-s', '--shell', help='output in a shell friendly way')
+    format_group.add_argument('-j', '--json', help='output json')
+
+    parser.add_argument('-d', '--shell-delim', default=':',
+        help='delimiter to use with shell output')
+
+    args = parser.parse_args()
+
+    
+    if args.json:
+        def dump(v, prefix=None):
+            return json.dumps(v, indent=4)
+    else:
+        def dump(v, prefix=None):
+            no_prefix = prefix is None
+            if no_prefix:
+                prefix = []
+            out = []
+            if isinstance(v, dict):
+                for k, vs in v.items():
+                    out.extend(dump(vs, [*prefix, k]))
+            elif isinstance(v, list):
+                for v in v:
+                    out.extend(dump(v, prefix))
+            elif isinstance(v, str):
+                out.append(':'.join([*prefix, v]))
+            else:
+                raise TypeError(
+                    "don't know how to format {type(v)} in a shell friendly way")
+            if no_prefix:
+                return '\n'.join(out)
+            else:
+                return out
+
+    data = mkparser.parse_makefile(args.makefile).to_dict()
+
+    if args.var:
+        if isinstance(args.var, str):
+            if args.var in data['variables']:
+                print(dump(data['variables'][args.var]))
+            else:
+                print("variable not found", file=sys.stderr)
+        else:
+            print(dump(data['variables']))
+    elif args.included:
+        print(dump(data['included']))
+    else:
+        print(dump(data))


### PR DESCRIPTION
requires https://github.com/turnkeylinux/tkldev-detective/pull/2

dynamically find changelogs in ``/turnkey/fab/common/changes/<name>.changelog`` that match makefile names in common.

if an appliance uses the lamp makefile for example, this tkldev-changelog will now automatically add new changelog entries from ``/turnkey/fab/common/changes/lamp.changelog``